### PR TITLE
Fix code scanning alert no. 2: DOM text reinterpreted as HTML

### DIFF
--- a/static/color-chooser.html
+++ b/static/color-chooser.html
@@ -222,7 +222,7 @@
     document.getElementById("findColor").addEventListener("click", () => {
       const colorInput = document.getElementById("colorInput").value;
       const resultDiv = document.getElementById("result");
-      resultDiv.innerHTML = "";
+      resultDiv.textContent = "";
 
       const nearestColor = findNearestColorFromGroups(colorInput);
       if (nearestColor) {
@@ -230,21 +230,29 @@
           <div class="comparison">
             <div>
               <p>Original color:</p>
-              <div class="color-box" style="background-color: ${colorInput};"></div>
-              <p>${colorInput}</p>
+              <div class="color-box" style="background-color: ${escapeHtml(colorInput)};"></div>
+              <p>${escapeHtml(colorInput)}</p>
             </div>
             <div>
               <p>Nearest color:</p>
-              <div class="color-box" style="background-color: ${nearestColor.value};"></div>
-              <p>${nearestColor.name} (${nearestColor.value})</p>
-              <p>Group: ${nearestColor.group}</p>
+              <div class="color-box" style="background-color: ${escapeHtml(nearestColor.value)};"></div>
+              <p>${escapeHtml(nearestColor.name)} (${escapeHtml(nearestColor.value)})</p>
+              <p>Group: ${escapeHtml(nearestColor.group)}</p>
             </div>
           </div>
         `;
       } else {
-        resultDiv.innerHTML = `<p>Invalid color input. Please enter a valid hex color code.</p>`;
+        resultDiv.textContent = "Invalid color input. Please enter a valid hex color code.";
       }
     });
+    function escapeHtml(unsafe) {
+      return unsafe
+        .replace(/&/g, "&amp;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;")
+        .replace(/"/g, "&quot;")
+        .replace(/'/g, "&#039;");
+    }
   </script>
 </body>
 </html>


### PR DESCRIPTION
Fixes [https://github.com/davidsneighbour/hugo-darkskies/security/code-scanning/2](https://github.com/davidsneighbour/hugo-darkskies/security/code-scanning/2)

To fix the problem, we need to ensure that any user input is properly sanitized before being inserted into the HTML. This can be achieved by using textContent instead of innerHTML for inserting plain text, and by properly escaping any dynamic content that is inserted into the HTML.

- Replace the use of `innerHTML` with `textContent` for plain text.
- Use a function to escape any dynamic content that needs to be inserted into the HTML.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
